### PR TITLE
fixed initial migration (included `related_name` and `help_text`)

### DIFF
--- a/robots/migrations/0001_initial.py
+++ b/robots/migrations/0001_initial.py
@@ -40,13 +40,13 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='rule',
             name='disallowed',
-            field=models.ManyToManyField(blank=True, to='robots.Url', verbose_name='disallowed'),
+            field=models.ManyToManyField(to='robots.Url', blank=True, related_name='disallowed', verbose_name='disallowed', help_text='The URLs which are not allowed to be accessed by bots.'),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='rule',
             name='allowed',
-            field=models.ManyToManyField(blank=True, to='robots.Url', verbose_name='allowed'),
+            field=models.ManyToManyField(to='robots.Url', blank=True, related_name='allowed', verbose_name='allowed', help_text='The URLs which are allowed to be accessed by bots.'),
             preserve_default=True,
         ),
     ]


### PR DESCRIPTION
Not sure how, but these were left out of the migration in #23.  I noticed this after making a custom management command to check for un-migrated model changes in my project.

These changes do not impact the contents of the database (which is why I did not create a separate migration), but for some reason Django requires the migrations to explicitly mention them.