### PR TITLE
disable localization of decimal fields in template

### DIFF
--- a/robots/templates/robots/rule_list.html
+++ b/robots/templates/robots/rule_list.html
@@ -1,8 +1,8 @@
-{% if rules %}{% for rule in rules %}{% ifchanged rule.robot %}{% if not forloop.first %}
+{% load l10n %}{% if rules %}{% for rule in rules %}{% ifchanged rule.robot %}{% if not forloop.first %}
 {% endif %}User-agent: {{ rule.robot }}{% endifchanged %}
 {% for url in rule.allowed.all %}Allow: {{ url.pattern }}
 {% endfor %}{% for url in rule.disallowed.all %}Disallow: {{ url.pattern }}
-{% endfor %}{% if rule.crawl_delay %}Crawl-delay: {{ rule.crawl_delay }}
+{% endfor %}{% if rule.crawl_delay %}Crawl-delay: {% localize off %}{{ rule.crawl_delay }}{% endlocalize %}
 {% endif %}{% endfor %}{% else %}User-agent: *
 Allow: /
 {% endif %}


### PR DESCRIPTION
if you use german localization and USE_L10N is on in settings, decimal fields are rendered using **,** instead of **.** which violates the rfc standard.

this change disables the localized rendering of the decimal field (crawl_delay) fixind the problem